### PR TITLE
Updated Security Center API documentation links and Developer Portal links.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -184,7 +184,7 @@ intersphinx_mapping = {
 }
 
 extlinks = {
-    'devportal': ('https://developer.tenable.com/reference#%s', 'devportal'),
-    'sc-api': ('https://docs.tenable.com/sccv/api/%s', 'sc-api'),
+    'devportal': ('https://developer.tenable.com/reference/%s', 'devportal'),
+    'sc-api': ('https://docs.tenable.com/security-center/api/%s', 'sc-api'),
     'requests': ('https://requests.readthedocs.io/en/master/%s', 'requests'),
 }

--- a/tenable/io/remediation_scans.py
+++ b/tenable/io/remediation_scans.py
@@ -73,7 +73,7 @@ class RemediationScansAPI(TIOEndpoint):
 
             For further information on credentials, what settings to use, etc,
             refer to
-            `this doc <https://developer.tenable.com/reference#io-scans-remediation-list>`_  # noqa: E501
+            `this doc <https://developer.tenable.com/reference/io-scans-remediation-list>`_  # noqa: E501
             on the developer portal.
 
             '''
@@ -174,7 +174,7 @@ class RemediationScansAPI(TIOEndpoint):
 
             For further information on credentials, what settings to use, etc,
             refer to
-            `this doc <https://developer.tenable.com/reference#io-scans-remediation-create>`_
+            `this doc <https://developer.tenable.com/reference/io-scans-remediation-create>`_
             on the developer portal.
 
         '''

--- a/tenable/sc/__init__.py
+++ b/tenable/sc/__init__.py
@@ -165,9 +165,9 @@ class TenableSC(APIPlatform):  # noqa PLR0904
     the `SC API Best Practices Guide`_.
 
     .. _SC API documentation:
-        https://docs.tenable.com/sccv/api/index.html
+        https://docs.tenable.com/security-center/api/index.htm
     .. _SC API Best Practices Guide:
-        https://docs.tenable.com/sccv/api_best_practices/Content/ScApiBestPractices/AboutScApiBestPrac.htm
+        https://docs.tenable.com/security-center/api_best_practices/Content/AboutScApiBestPrac.htm
     .. _Requests Client-Side Certificates:
         http://docs.python-requests.org/en/master/user/advanced/#client-side-certificates
     .. _requests_pkcs12:

--- a/tenable/sc/accept_risks.py
+++ b/tenable/sc/accept_risks.py
@@ -3,7 +3,7 @@ Accept Risks
 ============
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`Accept Risk <Accept-Risk-Rule.html>` API.
+:sc-api:`Accept Risk <Accept-Risk-Rule.htm>` API.
 
 Methods available on ``sc.accept_risks``:
 
@@ -79,7 +79,7 @@ class AcceptRiskAPI(SCEndpoint):
         '''
         Retrieves the list of accepted risk rules.
 
-        :sc-api:`accept-risk: list <Accept-Risk-Rule.html#AcceptRiskRuleRESTReference-/acceptRiskRule>`
+        :sc-api:`accept-risk: list <Accept-Risk-Rule.htm#AcceptRiskRuleRESTReference-/acceptRiskRule>`
 
         Args:
             fields (list, optional):
@@ -136,7 +136,7 @@ class AcceptRiskAPI(SCEndpoint):
         '''
         Retrieves the details of an accepted risk rule.
 
-        :sc-api:`accept-riskL details <Accept-Risk-Rule.html#AcceptRiskRuleRESTReference-/acceptRiskRule/{id}>`
+        :sc-api:`accept-riskL details <Accept-Risk-Rule.htm#AcceptRiskRuleRESTReference-/acceptRiskRule/{id}>`
 
         Args:
             id (int): The identifier for the accept risk rule.
@@ -163,7 +163,7 @@ class AcceptRiskAPI(SCEndpoint):
         '''
         Removes the accepted risk rule from Tenable.sc
 
-        :sc-api:`accept-risk: delete <Accept-Risk-Rule.html#acceptRiskRule_id_DELETE>`
+        :sc-api:`accept-risk: delete <Accept-Risk-Rule.htm#acceptRiskRule_id_DELETE>`
 
         Args:
             id (int): The identifier for the accept risk rule.
@@ -183,7 +183,7 @@ class AcceptRiskAPI(SCEndpoint):
         Applies the accept risk rule for either all repositories, or the
         repository specified.
 
-        :sc-api:`accept-risk: apply <Accept-Risk-Rule.html#AcceptRiskRuleRESTReference-/acceptRiskRule/apply>`
+        :sc-api:`accept-risk: apply <Accept-Risk-Rule.htm#AcceptRiskRuleRESTReference-/acceptRiskRule/apply>`
 
         Args:
             id (int): The identifier for the accept risk rule.
@@ -208,7 +208,7 @@ class AcceptRiskAPI(SCEndpoint):
         Creates a new accept risk rule.  Either ips, uuids, or asset_list must
         be specified.
 
-        :sc-api:`accept-risk: create <Accept-Risk-Rule.html#acceptRiskRule_POST>`
+        :sc-api:`accept-risk: create <Accept-Risk-Rule.htm#acceptRiskRule_POST>`
 
         Args:
             plugin_id (int): The plugin to apply the accept risk rule to.

--- a/tenable/sc/alerts.py
+++ b/tenable/sc/alerts.py
@@ -3,7 +3,7 @@ Alerts
 ======
 
 The following methods allow for interaction into the Tenable.sc
-`Alert <https://docs.tenable.com/sccv/api/Alert.html>`_ API.
+`Alert <https://docs.tenable.com/security-center/api/Alert.htm>`_ API.
 
 Methods available on ``sc.alerts``:
 
@@ -85,7 +85,7 @@ class AlertAPI(SCEndpoint):
         '''
         Retrieves the list of alerts.
 
-        :sc-api:`alert: list <Alert.html#AlertRESTReference-/alert>`
+        :sc-api:`alert: list <Alert.htm#AlertRESTReference-/alert>`
 
         Args:
             fields (list, optional):
@@ -110,7 +110,7 @@ class AlertAPI(SCEndpoint):
         '''
         Returns the details for a specific alert.
 
-        :sc-api:`alert: details <Alert.html#AlertRESTReference-/alert/{id}>`
+        :sc-api:`alert: details <Alert.htm#AlertRESTReference-/alert/{id}>`
 
         Args:
             id (int): The identifier for the alert.
@@ -137,7 +137,7 @@ class AlertAPI(SCEndpoint):
         any additional parameters mentioned in the API docs can be passed to the
         document constructor.
 
-        :sc-api:'alert: create <Alert.html#alert_POST>`
+        :sc-api:'alert: create <Alert.htm#alert_POST>`
 
         Args:
             *filters (tuple):
@@ -247,7 +247,7 @@ class AlertAPI(SCEndpoint):
         Updates an existing alert.  All fields are optional and will overwrite
         the existing value.
 
-        :sc-api:`alert: update <Alert.html#alert_id_PATCH>`
+        :sc-api:`alert: update <Alert.htm#alert_id_PATCH>`
 
         Args:
             if (int): The alert identifier.
@@ -293,7 +293,7 @@ class AlertAPI(SCEndpoint):
         '''
         Deletes the specified alert.
 
-        :sc-api:`alert: delete <Alert.html#alert_id_DELETE>`
+        :sc-api:`alert: delete <Alert.htm#alert_id_DELETE>`
 
         Args:
             id (int): The alert identifier.
@@ -312,7 +312,7 @@ class AlertAPI(SCEndpoint):
         '''
         Executes the specified alert.
 
-        :sc-api:`alert: execute <Alert.html#AlertRESTReference-/alert/{id}/execute>`
+        :sc-api:`alert: execute <Alert.htm#AlertRESTReference-/alert/{id}/execute>`
 
         Args:
             id (int): The alert identifier.

--- a/tenable/sc/analysis.py
+++ b/tenable/sc/analysis.py
@@ -3,7 +3,7 @@ Analysis
 ========
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`analysis <Analysis.html>` API.  The analysis area in Tenable.sc is
+:sc-api:`analysis <Analysis.htm>` API.  The analysis area in Tenable.sc is
 highly complex and allows for a wide range of varied inputs and outputs.  This
 single endpoint has been broken down in pyTenable to several methods in order to
 apply some defaults to the expected data-types and options most likely to be
@@ -205,7 +205,7 @@ class AnalysisAPI(SCEndpoint):
         Query's the analysis API for vulnerability data within the cumulative
         repositories.
 
-        :sc-api:`analysis: vuln-type <Analysis.html#AnalysisRESTReference-VulnType>`
+        :sc-api:`analysis: vuln-type <Analysis.htm#AnalysisRESTReference-VulnType>`
 
         Args:
             filters (tuple, optional):
@@ -355,7 +355,7 @@ class AnalysisAPI(SCEndpoint):
         '''
         Queries the analysis API for vulnerability data from a specific scan.
 
-        :sc-api:`analysis: vuln-type <Analysis.html#AnalysisRESTReference-VulnType>`
+        :sc-api:`analysis: vuln-type <Analysis.htm#AnalysisRESTReference-VulnType>`
 
         Args:
             scan_id (int):
@@ -436,7 +436,7 @@ class AnalysisAPI(SCEndpoint):
         '''
         Queries the analysis API for event data from the Log Correlation Engine
 
-        :sc-api:`analysis: event-type <Analysis.html#AnalysisRESTReference-EventType>`
+        :sc-api:`analysis: event-type <Analysis.htm#AnalysisRESTReference-EventType>`
 
         Args:
             filters (tuple, optional):
@@ -536,7 +536,7 @@ class AnalysisAPI(SCEndpoint):
         '''
         Queries the analysis API for log data from the Tenable.sc Console itself.
 
-        :sc-api:`analysis: sclog-type <Analysis.html#AnalysisRESTReference-SCLogType>`
+        :sc-api:`analysis: sclog-type <Analysis.htm#AnalysisRESTReference-SCLogType>`
 
         Args:
             filters (tuple, optional):
@@ -577,7 +577,7 @@ class AnalysisAPI(SCEndpoint):
         Queries the analysis API for mobile data collected from querying one or
         many MDM solutions.
 
-        :sc-api:`analysis: mobile-type <Analysis.html#AnalysisRESTReference-MobileType>`
+        :sc-api:`analysis: mobile-type <Analysis.htm#AnalysisRESTReference-MobileType>`
 
         Args:
             filters (tuple, optional):

--- a/tenable/sc/asset_lists.py
+++ b/tenable/sc/asset_lists.py
@@ -3,7 +3,7 @@ Asset Lists
 ===========
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`Assets <Asset.html>` API.  These items are typically seen
+:sc-api:`Assets <Asset.htm>` API.  These items are typically seen
 under the **Assets** section of Tenable.sc.
 
 Methods available on ``sc.asset_lists``:
@@ -294,7 +294,7 @@ class AssetListAPI(SCEndpoint):
         '''
         Creates an asset-list.
 
-        :sc-api:`asset-list: create <Asset.html#asset_POST>`
+        :sc-api:`asset-list: create <Asset.htm#asset_POST>`
 
         Args:
             name (str):
@@ -439,7 +439,7 @@ class AssetListAPI(SCEndpoint):
         '''
         Returns the details for a specific asset-list.
 
-        :sc-api:`asset-list: details<Asset.html#AssetRESTReference-/asset/{id}?orgID={org_id}>`
+        :sc-api:`asset-list: details<Asset.htm#AssetRESTReference-/asset/{id}?orgID={org_id}>`
 
         Args:
             id (int): The identifier for the asset-list.
@@ -464,7 +464,7 @@ class AssetListAPI(SCEndpoint):
         '''
         Edits an asset-list.
 
-        :sc-api:`asset-list: edit <Asset.html#asset_id_PATCH>`
+        :sc-api:`asset-list: edit <Asset.htm#asset_id_PATCH>`
 
         Args:
             id (int):
@@ -566,7 +566,7 @@ class AssetListAPI(SCEndpoint):
         '''
         Removes a asset-list.
 
-        :sc-api:`asset-list: delete <Asset.html#asset_id_DELETE>`
+        :sc-api:`asset-list: delete <Asset.htm#asset_id_DELETE>`
 
         Args:
             id (int): The numeric identifier for the asset-list to remove.
@@ -584,7 +584,7 @@ class AssetListAPI(SCEndpoint):
         '''
         Retrieves the list of asset list definitions.
 
-        :sc-api:`asset-list: list <Asset.html#AssetRESTReference-/asset>`
+        :sc-api:`asset-list: list <Asset.htm#AssetRESTReference-/asset>`
 
         Args:
             fields (list, optional):
@@ -608,7 +608,7 @@ class AssetListAPI(SCEndpoint):
         '''
         Imports an asset list definition from an asset list definition XML file.
 
-        :sc-api:`asset-list: import <Asset.html#asset_import_POST>`
+        :sc-api:`asset-list: import <Asset.htm#asset_import_POST>`
 
         Args:
             name (str): The name of the asset definition to create.
@@ -633,7 +633,7 @@ class AssetListAPI(SCEndpoint):
         Exports an asset list definition and stored the data in the file-like
         object that was passed.
 
-        :sc-api:`asset-list: export <Asset.html#AssetRESTReference-/asset/{id}/export>`
+        :sc-api:`asset-list: export <Asset.htm#AssetRESTReference-/asset/{id}/export>`
 
         Args:
             id (int): The numeric identifier for the asset list to export.
@@ -669,7 +669,7 @@ class AssetListAPI(SCEndpoint):
         Initiates an on-demand recalculation of the asset list.  Note this
         endpoint requires being logged in as an admin user.
 
-        :sc-api:`asset-list: refresh <Asset.html#AssetRESTReference-/asset/{id}/refresh>`
+        :sc-api:`asset-list: refresh <Asset.htm#AssetRESTReference-/asset/{id}/refresh>`
 
         Args:
             id (int): The numeric identifier of the asset list to refresh.
@@ -699,7 +699,7 @@ class AssetListAPI(SCEndpoint):
         '''
         Performs a LDAP test query on the specified LDAP service configured.
 
-        :sc-api:`asset-list: test-ldap-query <Asset.html#AssetRESTReference-/asset/testLDAPQuery>`
+        :sc-api:`asset-list: test-ldap-query <Asset.htm#AssetRESTReference-/asset/testLDAPQuery>`
 
         Args:
             ldap_id (int):
@@ -726,7 +726,7 @@ class AssetListAPI(SCEndpoint):
         '''
         Retrieves the list of unique tags associated to asset lists.
 
-        :sc-api:`asset-lists: tags <Asset.html#AssetRESTReference-/asset/tag>`
+        :sc-api:`asset-lists: tags <Asset.htm#AssetRESTReference-/asset/tag>`
 
         Returns:
             :obj:`list`:
@@ -741,7 +741,7 @@ class AssetListAPI(SCEndpoint):
         '''
         Shares the specified asset list to another user group.
 
-        :sc-api:`asset-lists: share <Asset.html#AssetRESTReference-/asset/{id}/share>`
+        :sc-api:`asset-lists: share <Asset.htm#AssetRESTReference-/asset/{id}/share>`
 
         Args:
             id (int): The numeric id for the credential.

--- a/tenable/sc/audit_files.py
+++ b/tenable/sc/audit_files.py
@@ -3,8 +3,8 @@ Audit Files
 ===========
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`Audit File <AuditFile.html>` API and the
-:sc-api:`Audit File Template <AuditFile-Template.html>` API.  These items are
+:sc-api:`Audit File <AuditFile.htm>` API and the
+:sc-api:`Audit File Template <AuditFile-Template.htm>` API.  These items are
 typically seen under the **Scans: Audit Files** section of Tenable.sc.
 
 Methods available on ``sc.audit_files``:
@@ -103,7 +103,7 @@ class AuditFileAPI(SCEndpoint):
         '''
         Creates a audit file.
 
-        :sc-api:`audit file: create <AuditFile.html#auditFile_POST>`
+        :sc-api:`audit file: create <AuditFile.htm#auditFile_POST>`
 
         Args:
             name (str):
@@ -173,7 +173,7 @@ class AuditFileAPI(SCEndpoint):
         '''
         Returns the details for a specific audit file.
 
-        :sc-api:`audit file: details <AuditFile.html#AuditFileRESTReference-/auditFile/{id}>`
+        :sc-api:`audit file: details <AuditFile.htm#AuditFileRESTReference-/auditFile/{id}>`
 
         Args:
             id (int): The identifier for the audit file.
@@ -198,7 +198,7 @@ class AuditFileAPI(SCEndpoint):
         '''
         Edits a audit file.
 
-        :sc-api:`audit file: edit <AuditFile.html#auditFile_id_PATCH>`
+        :sc-api:`audit file: edit <AuditFile.htm#auditFile_id_PATCH>`
 
         Args:
             audit_file (FileObject, optional):
@@ -268,7 +268,7 @@ class AuditFileAPI(SCEndpoint):
         '''
         Removes a audit file.
 
-        :sc-api:`audit file: delete <AuditFile.html#auditFile_id_DELETE>`
+        :sc-api:`audit file: delete <AuditFile.htm#auditFile_id_DELETE>`
 
         Args:
             id (int): The numeric identifier for the audit file to remove.
@@ -287,7 +287,7 @@ class AuditFileAPI(SCEndpoint):
         '''
         Retrieves the list of audit file definitions.
 
-        :sc-api:`audit file: list <AuditFile.html#AuditFileRESTReference-/auditFile>`
+        :sc-api:`audit file: list <AuditFile.htm#AuditFileRESTReference-/auditFile>`
 
         Args:
             fields (list, optional):
@@ -312,7 +312,7 @@ class AuditFileAPI(SCEndpoint):
         '''
         Exports an Audit File.
 
-        :sc-api:`audit file: export <AuditFile.html#AuditFileRESTReference-/auditFile/{id}/export>`
+        :sc-api:`audit file: export <AuditFile.htm#AuditFileRESTReference-/auditFile/{id}/export>`
 
         Args:
             id (int): The audit file numeric identifier.
@@ -352,7 +352,7 @@ class AuditFileAPI(SCEndpoint):
         '''
         Returns the audit file template categories
 
-        :sc-api:`audit template: categories <AuditFile-Template.html#auditFileTemplate_categories_GET>`
+        :sc-api:`audit template: categories <AuditFile-Template.htm#auditFileTemplate_categories_GET>`
 
         Returns:
             :obj:`list`:
@@ -368,7 +368,7 @@ class AuditFileAPI(SCEndpoint):
         '''
         Returns the details for the specified audit file template id.
 
-        :sc-api:`audit template: details <AuditFile-Template.html#auditFileTemplate_id_GET>`
+        :sc-api:`audit template: details <AuditFile-Template.htm#auditFileTemplate_id_GET>`
 
         Args:
             id (int):
@@ -395,7 +395,7 @@ class AuditFileAPI(SCEndpoint):
         '''
         Returns the list of audit file templates.
 
-        :sc-api:`audit templates: list <AuditFile-Template.html#AuditFileTemplateRESTReference-/auditFileTemplate>`
+        :sc-api:`audit templates: list <AuditFile-Template.htm#AuditFileTemplateRESTReference-/auditFileTemplate>`
 
         Args:
             category (int, optional):

--- a/tenable/sc/credentials.py
+++ b/tenable/sc/credentials.py
@@ -3,7 +3,7 @@ Credentials
 ===========
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`Scan Credentials <Credential.html>` API.  These
+:sc-api:`Scan Credentials <Credential.htm>` API.  These
 items are typically seen under the **Scan Credentials** section of Tenable.sc.
 
 Methods available on ``sc.credentials``:
@@ -406,7 +406,7 @@ class CredentialAPI(SCEndpoint):
         '''
         Creates a credential.
 
-        :sc-api:`credential: create <Credential.html#credential_POST>`
+        :sc-api:`credential: create <Credential.htm#credential_POST>`
 
         Args:
             name (str): The name for the credential.
@@ -683,7 +683,7 @@ class CredentialAPI(SCEndpoint):
         '''
         Returns the details for a specific credential.
 
-        :sc-api:`credential: details <Credential.html#CredentialRESTReference-/credential/{id}>`
+        :sc-api:`credential: details <Credential.htm#CredentialRESTReference-/credential/{id}>`
 
         Args:
             id (int): The identifier for the credential.
@@ -708,7 +708,7 @@ class CredentialAPI(SCEndpoint):
         '''
         Edits a credential.
 
-        :sc-api:`credential: edit <Credential.html#credential_id_PATCH>`
+        :sc-api:`credential: edit <Credential.htm#credential_id_PATCH>`
 
         Args:
             auth_type (str, optional):
@@ -903,7 +903,7 @@ class CredentialAPI(SCEndpoint):
         '''
         Removes a credential.
 
-        :sc-api:`credential: delete <Credential.html#credential_id_DELETE>`
+        :sc-api:`credential: delete <Credential.htm#credential_id_DELETE>`
 
         Args:
             id (int): The numeric identifier for the credential to remove.
@@ -922,7 +922,7 @@ class CredentialAPI(SCEndpoint):
         '''
         Retrieves the list of credential definitions.
 
-        + :sc-api:`credential: list <Credential.html#CredentialRESTReference-/credential>`
+        + :sc-api:`credential: list <Credential.htm#CredentialRESTReference-/credential>`
 
         Args:
             fields (list, optional):
@@ -947,7 +947,7 @@ class CredentialAPI(SCEndpoint):
         '''
         Retrieves the list of unique tags associated to credentials.
 
-        :sc-api:`credential: tags <Credential.html#CredentialRESTReference-/credential/tag>`
+        :sc-api:`credential: tags <Credential.htm#CredentialRESTReference-/credential/tag>`
 
         Returns:
             :obj:`list`:
@@ -962,7 +962,7 @@ class CredentialAPI(SCEndpoint):
         '''
         Shares the specified credential to another user group.
 
-        :sc-api:`credential: share <Credential.html#CredentialRESTReference-/credential/{id}/share>`
+        :sc-api:`credential: share <Credential.htm#CredentialRESTReference-/credential/{id}/share>`
 
         Args:
             id (int): The numeric id for the credential.

--- a/tenable/sc/current.py
+++ b/tenable/sc/current.py
@@ -3,7 +3,7 @@ Current Session
 ===============
 
 The following methods allow for interaction with the Tenable.sc
-:sc-api:`CurrentOrganization <Current-Organization.html>` API and the
+:sc-api:`CurrentOrganization <Current-Organization.htm>` API and the
 :sc-api:`CurrentUser <>` API.
 
 Methods available on ``sc.current``:
@@ -34,7 +34,7 @@ class CurrentSessionAPI(SCEndpoint):
         '''
         Returns the organization of the current session.
 
-        :sc-api:`current-organization <Current-Organization.html>`
+        :sc-api:`current-organization <Current-Organization.htm>`
 
         Args:
             fields (list, optional):
@@ -58,7 +58,7 @@ class CurrentSessionAPI(SCEndpoint):
         '''
         Returns the user of the current session.
 
-        :sc-api:`current-user </Current-User.html>`
+        :sc-api:`current-user </Current-User.htm>`
 
         Args:
             fields (list, optional):

--- a/tenable/sc/feeds.py
+++ b/tenable/sc/feeds.py
@@ -3,7 +3,7 @@ Feeds
 =====
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`Feed <Feed.html>` API.
+:sc-api:`Feed <Feed.htm>` API.
 
 Methods available on ``sc.feeds``:
 
@@ -19,9 +19,9 @@ class FeedAPI(SCEndpoint):
         Returns the status of either a specific feed type (if requested) or all
         of the feed types if nothing is specifically asked.
 
-        :sc-api:`feed <Feed.html>`
+        :sc-api:`feed <Feed.htm>`
 
-        :sc-api:`feed: feed-type <Feed.html#FeedRESTReference-FeedGETType>`
+        :sc-api:`feed: feed-type <Feed.htm#FeedRESTReference-FeedGETType>`
 
         Args:
             feed_type (str, optional):
@@ -58,7 +58,7 @@ class FeedAPI(SCEndpoint):
         no feed type is specified, then it will default to initiating an update
         for all feed types.
 
-        :sc-api:`feed: update <Feed.html#FeedRESTReference-FeedUpdatePOSTType>`
+        :sc-api:`feed: update <Feed.htm#FeedRESTReference-FeedUpdatePOSTType>`
 
         Args:
             feed_type (str, optional);
@@ -77,7 +77,7 @@ class FeedAPI(SCEndpoint):
         Initiates an off-line feed update based on the specified feed_type using
         the file object passed as the update file.
 
-        :sc-api:`feed: process <Feed.html#FeedRESTReference-FeedUpdatePOSTProcess>`
+        :sc-api:`feed: process <Feed.htm#FeedRESTReference-FeedUpdatePOSTProcess>`
 
         Args:
             feed_type (str);

--- a/tenable/sc/files.py
+++ b/tenable/sc/files.py
@@ -3,7 +3,7 @@ Files
 =====
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`File <File.html>` API.
+:sc-api:`File <File.htm>` API.
 
 Methods available on ``sc.files``:
 
@@ -19,7 +19,7 @@ class FileAPI(SCEndpoint):
         Uploads a file into SecurityCenter and returns the file identifier
         to be used for subsequent calls.
 
-        :sc-api:`file: upload <File.html#FileRESTReference-/file/upload>`
+        :sc-api:`file: upload <File.htm#FileRESTReference-/file/upload>`
 
         Args:
             fobj (FileObj): The file object to upload into SecurityCenter.
@@ -36,7 +36,7 @@ class FileAPI(SCEndpoint):
         '''
         Removes the requested file from Tenable.sc.
 
-        :sc-api:`file: clear <File.html#FileRESTReference-/file/clear>`
+        :sc-api:`file: clear <File.htm#FileRESTReference-/file/clear>`
 
         Args:
             filename (str): The file identifier associated to the file.

--- a/tenable/sc/groups.py
+++ b/tenable/sc/groups.py
@@ -3,7 +3,7 @@ Groups
 ======
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`Group <Group.html>` API.  These items are typically seen under the
+:sc-api:`Group <Group.htm>` API.  These items are typically seen under the
 **User Groups** section of Tenable.sc.
 
 Methods available on ``sc.groups``:
@@ -52,7 +52,7 @@ class GroupAPI(SCEndpoint):
         '''
         Creates a group.
 
-        :sc-api:`group: create <Group.html#group_POST>`
+        :sc-api:`group: create <Group.htm#group_POST>`
 
         Args:
             name (str): The name of the user group
@@ -93,7 +93,7 @@ class GroupAPI(SCEndpoint):
         '''
         Returns the details for a specific group.
 
-        :sc-api:`group: details <Group.html#GroupRESTReference-/group/{id}>`
+        :sc-api:`group: details <Group.htm#GroupRESTReference-/group/{id}>`
 
         Args:
             id (int): The identifier for the group.
@@ -118,7 +118,7 @@ class GroupAPI(SCEndpoint):
         '''
         Edits a group.
 
-        :sc-api:`group: edit <Group.html#group_id_PATCH>`
+        :sc-api:`group: edit <Group.htm#group_id_PATCH>`
 
         Args:
             asset_lists (list, optional):
@@ -160,7 +160,7 @@ class GroupAPI(SCEndpoint):
         '''
         Removes a group.
 
-        :sc-api:`group: delete <Group.html#group_id_DELETE>`
+        :sc-api:`group: delete <Group.htm#group_id_DELETE>`
 
         Args:
             id (int): The numeric identifier for the group to remove.
@@ -179,7 +179,7 @@ class GroupAPI(SCEndpoint):
         '''
         Retrieves the list of group definitions.
 
-        :sc-api:`group: list <Group.html#group_GET>`
+        :sc-api:`group: list <Group.htm#group_GET>`
 
         Args:
             fields (list, optional):

--- a/tenable/sc/organizations.py
+++ b/tenable/sc/organizations.py
@@ -3,7 +3,7 @@ Organizations
 =============
 
 The following methods allow for interaction with the Tenable.sc
-:sc-api:`Organization <Organization.html>` API. These items are typically seen
+:sc-api:`Organization <Organization.htm>` API. These items are typically seen
 under the **Organization** section of Tenable.sc.
 
 Methods available on ``sc.organizations``:
@@ -133,7 +133,7 @@ class OrganizationAPI(SCEndpoint):
         '''
         Create a new organization
 
-        :sc-api:`SC Organization Create <Organization.html#organization_POST>`
+        :sc-api:`SC Organization Create <Organization.htm#organization_POST>`
 
         Args:
             name (str): The name for organization.
@@ -208,7 +208,7 @@ class OrganizationAPI(SCEndpoint):
         '''
         Retrieves a list of organizations.
 
-        :sc-api:`SC organization List <Organization.html#OrganizationRESTReference-/organization>`  # noqa: E501
+        :sc-api:`SC organization List <Organization.htm#OrganizationRESTReference-/organization>`  # noqa: E501
 
         Args:
             fields (list, optional):
@@ -236,7 +236,7 @@ class OrganizationAPI(SCEndpoint):
         '''
         Retrieves the details for the specified organization.
 
-        :sc-api:`SC Organization Details <Organization.html#organization_id_GET>`  # noqa: E501
+        :sc-api:`SC Organization Details <Organization.htm#organization_id_GET>`  # noqa: E501
 
         Args:
             organization_id (int): The numeric id of the organization.
@@ -267,7 +267,7 @@ class OrganizationAPI(SCEndpoint):
         '''
         Updates an existing organization
 
-        :sc-api:`SC Organization Edit <Organization.html#organization_id_PATCH>`  # noqa: E501
+        :sc-api:`SC Organization Edit <Organization.htm#organization_id_PATCH>`  # noqa: E501
 
         Args:
             organization_id: The numeric id of the organization.
@@ -328,7 +328,7 @@ class OrganizationAPI(SCEndpoint):
         '''
         Remove the specified organization from Tenable.sc
 
-        :sc-api:`SC organization Delete <Organization.html#organization_id_DELETE>`  # noqa: E501
+        :sc-api:`SC organization Delete <Organization.htm#organization_id_DELETE>`  # noqa: E501
 
         Args:
             organization_id (int): The numeric id of the organization to delete.
@@ -356,7 +356,7 @@ class OrganizationAPI(SCEndpoint):
         will filter based on the parameters specified.
 
         :sc-api:`organization: accept-risk-rule
-        <Organization.html#OrganizationRESTReference-/organization/{organization_id}/acceptRiskRule>`  # noqa: E501
+        <Organization.htm#OrganizationRESTReference-/organization/{organization_id}/acceptRiskRule>`  # noqa: E501
 
         Args:
             organization_id (int): The organization id.
@@ -393,7 +393,7 @@ class OrganizationAPI(SCEndpoint):
         will filter based on the parameters specified.
 
         :sc-api:`organization: recast-risk-rule
-        <Organization.html#OrganizationRESTReference-/organization/{organization_id}/recastRiskRule>`  # noqa: E501
+        <Organization.htm#OrganizationRESTReference-/organization/{organization_id}/recastRiskRule>`  # noqa: E501
 
         Args:
             organization_id (int): The organization id.
@@ -428,7 +428,7 @@ class OrganizationAPI(SCEndpoint):
         '''
         Retrieves a list of security managers.
 
-        :sc-api:`organization-security-manager: list <Organization-Security-Manager.html#OrganizationSecurityManagerRESTReference-/organization/{orgID}/securityManager>`  # noqa: E501,PLC0301
+        :sc-api:`organization-security-manager: list <Organization-Security-Manager.htm#OrganizationSecurityManagerRESTReference-/organization/{orgID}/securityManager>`  # noqa: E501,PLC0301
 
         Args:
             org_id: (int):
@@ -460,7 +460,7 @@ class OrganizationAPI(SCEndpoint):
         of parameters that are supported for this call, please refer to
         :py:meth:`tio.users.create() <UserAPI.create>` for more details.
 
-        :sc-api:`organization-security-manager: create <Organization-Security-Manager.html#organization_orgID_securityManager_POST>`  # noqa: E501,PLC0301
+        :sc-api:`organization-security-manager: create <Organization-Security-Manager.htm#organization_orgID_securityManager_POST>`  # noqa: E501,PLC0301
 
         Args:
             org_id: (int):
@@ -497,7 +497,7 @@ class OrganizationAPI(SCEndpoint):
         Retrieves the details of a specified security manager within a
         specified organization.
 
-        :sc-api:`organization-security-manager: details <Organization-Security-Manager.html#OrganizationSecurityManagerRESTReference-/organization/{orgID}/securityManager/{id}>`  # noqa: E501,PLC0301
+        :sc-api:`organization-security-manager: details <Organization-Security-Manager.htm#OrganizationSecurityManagerRESTReference-/organization/{orgID}/securityManager/{id}>`  # noqa: E501,PLC0301
 
         Args:
             org_id: (int):
@@ -532,7 +532,7 @@ class OrganizationAPI(SCEndpoint):
         For details on the supported arguments that may be passed, please refer
         to :py:meth:`tio.users.edit() <UserAPI.edit>` for more details.
 
-        :sc-api:`organization-security-manager: edit <Organization-Security-Manager.html#organization_orgID_securityManager_id_PATCH>`  # noqa: E501,PLC0301
+        :sc-api:`organization-security-manager: edit <Organization-Security-Manager.htm#organization_orgID_securityManager_id_PATCH>`  # noqa: E501,PLC0301
 
         Args:
             org_id: (int):
@@ -561,7 +561,7 @@ class OrganizationAPI(SCEndpoint):
         '''
         Removes the user specified.
 
-        :sc-api:`organization-security-manager: delete <Organization-Security-Manager.html#organization_orgID_securityManager_id_DELETE>`  # noqa: E501,PLC0301
+        :sc-api:`organization-security-manager: delete <Organization-Security-Manager.htm#organization_orgID_securityManager_id_DELETE>`  # noqa: E501,PLC0301
 
         Args:
             org_id: (int):

--- a/tenable/sc/plugins.py
+++ b/tenable/sc/plugins.py
@@ -3,7 +3,7 @@ Plugins
 =======
 
 The following methods allow for interaction with the Tenable.sc
-:sc-api:`Plugins <Plugin.html>` API.  These items are typically seen under the
+:sc-api:`Plugins <Plugin.htm>` API.  These items are typically seen under the
 **Plugins** section of Tenable.sc.
 
 Methods available on ``sc.plugins``:
@@ -95,7 +95,7 @@ class PluginAPI(SCEndpoint):
         '''
         Retrieves the list of plugins.
 
-        :sc-api:`plugins: list <Plugin.html#PluginRESTReference-/plugin>`
+        :sc-api:`plugins: list <Plugin.htm#PluginRESTReference-/plugin>`
 
         Args:
             fields (list, optional):
@@ -163,7 +163,7 @@ class PluginAPI(SCEndpoint):
         '''
         Returns the details for a specific plugin.
 
-        :sc-api:`plugins: details <Plugin.html#PluginRESTReference-/plugin/{id}>`
+        :sc-api:`plugins: details <Plugin.htm#PluginRESTReference-/plugin/{id}>`
 
         Args:
             plugin_id (int): The identifier for the plugin.
@@ -187,7 +187,7 @@ class PluginAPI(SCEndpoint):
         '''
         Returns the list of plugin families.
 
-        :sc-api:`plugin-families: list <Plugin-Family.html#PluginFamilyRESTReference-/pluginFamily>`
+        :sc-api:`plugin-families: list <Plugin-Family.htm#PluginFamilyRESTReference-/pluginFamily>`
 
         Args:
             fields (list, optional):
@@ -221,7 +221,7 @@ class PluginAPI(SCEndpoint):
         '''
         Returns the details for the specified plugin family.
 
-        :sc-api:`plugin-family: details <https://docs.tenable.com/sccv/api/Plugin-Family.html#PluginFamilyRESTReference-/pluginFamily/{id}>`
+        :sc-api:`plugin-family: details <https://docs.tenable.com/security-center/api/Plugin-Family.htm#PluginFamilyRESTReference-/pluginFamily/{id}>`
 
         Args:
             plugin_id (int): The plugin family numeric identifier.
@@ -247,7 +247,7 @@ class PluginAPI(SCEndpoint):
         '''
         Retrieves the plugins for the specified family.
 
-        :sc-api:`plugin-family: plugins <Plugin-Family.html#PluginFamilyRESTReference-/pluginFamily/{id}/plugins::GET>`
+        :sc-api:`plugin-family: plugins <Plugin-Family.htm#PluginFamilyRESTReference-/pluginFamily/{id}/plugins::GET>`
 
         Args:
             plugin_id (int): The numeric identifier for the plugin family.

--- a/tenable/sc/policies.py
+++ b/tenable/sc/policies.py
@@ -3,7 +3,7 @@ Policies
 ========
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`Scan Policies <Scan-Policy.html>` API.  These items are typically seen
+:sc-api:`Scan Policies <Scan-Policy.htm>` API.  These items are typically seen
 under the **Scan Policies** section of Tenable.sc.
 
 Methods available on ``sc.policies``:
@@ -83,7 +83,7 @@ class ScanPolicyAPI(SCEndpoint):
         '''
         Retrieved the list of scan policy templates.
 
-        :sc-api:`scan-policy: template-list <Scan-Policy.html#policy_GET>`
+        :sc-api:`scan-policy: template-list <Scan-Policy.htm#policy_GET>`
 
         Args:
             fields (list, optional):
@@ -111,7 +111,7 @@ class ScanPolicyAPI(SCEndpoint):
         '''
         Retrieves the details for a specified policy template.
 
-        :sc-api:`scan-policy: template-details <Scan-Policy-Templates.html#policyTemplate_id_GET>`
+        :sc-api:`scan-policy: template-details <Scan-Policy-Templates.htm#policyTemplate_id_GET>`
 
         Args:
             id (int): The unique identifier for the policy template
@@ -168,7 +168,7 @@ class ScanPolicyAPI(SCEndpoint):
         '''
         Retrieved the list of Scan policies configured.
 
-        :sc-api:`scan-policy: list <Scan-Policy.html#policy_GET>`
+        :sc-api:`scan-policy: list <Scan-Policy.htm#policy_GET>`
 
         Args:
             fields (list, optional):
@@ -196,7 +196,7 @@ class ScanPolicyAPI(SCEndpoint):
         '''
         Retrieves the details for a specified policy.
 
-        :sc-api:`scan-policy: details <Scan-Policy.html#policy_id_GET>`
+        :sc-api:`scan-policy: details <Scan-Policy.htm#policy_id_GET>`
 
         Args:
             id (int): The unique identifier for the policy
@@ -225,7 +225,7 @@ class ScanPolicyAPI(SCEndpoint):
         '''
         Creates a new scan policy
 
-        :sc-api:`scan-policy: create <Scan-Policy.html#policy_POST>`
+        :sc-api:`scan-policy: create <Scan-Policy.htm#policy_POST>`
 
         Args:
             name (str): The Name of the new scan policy
@@ -284,7 +284,7 @@ class ScanPolicyAPI(SCEndpoint):
         '''
         Edits an existing scan policy
 
-        :sc-api:`scan-policy: edit <Scan-Policy.html#policy_id_PATCH>`
+        :sc-api:`scan-policy: edit <Scan-Policy.htm#policy_id_PATCH>`
 
         Args:
             id (int): The unique identifier to the scan policy to edit
@@ -343,7 +343,7 @@ class ScanPolicyAPI(SCEndpoint):
         '''
         Removes a configured scan policy.
 
-        :sc-api:`scan-policy: delete <Scan-Policy.html#policy_id_DELETE>`
+        :sc-api:`scan-policy: delete <Scan-Policy.htm#policy_id_DELETE>`
 
         Args:
             id (int): The unique identifier for the policy to remove.
@@ -362,7 +362,7 @@ class ScanPolicyAPI(SCEndpoint):
         '''
         Clones the specified scan policy
 
-        :sc-api:`scan-policy: copy <Scan-Policy.html#ScanPolicyRESTReference-/policy/{id}/copy>`
+        :sc-api:`scan-policy: copy <Scan-Policy.htm#ScanPolicyRESTReference-/policy/{id}/copy>`
 
         Args:
             id (int): The unique identifier for the source policy to clone.
@@ -386,7 +386,7 @@ class ScanPolicyAPI(SCEndpoint):
         '''
         Export the specified scan policy
 
-        :sc-api:`scan-policy: export <Scan-Policy.html#ScanPolicyRESTReference-/policy/{id}/export>`
+        :sc-api:`scan-policy: export <Scan-Policy.htm#ScanPolicyRESTReference-/policy/{id}/export>`
 
         Args:
             id (int): The unique identifier for the scan policy to export.
@@ -426,7 +426,7 @@ class ScanPolicyAPI(SCEndpoint):
         '''
         Imports a scan policy into Tenable.sc
 
-        :sc-api:`scan-policy: import <Scan-Policy.html#ScanPolicyRESTReference-/policy/import>`
+        :sc-api:`scan-policy: import <Scan-Policy.htm#ScanPolicyRESTReference-/policy/import>`
 
         Args:
             name (str): The name of the imported scan policy.
@@ -454,7 +454,7 @@ class ScanPolicyAPI(SCEndpoint):
         '''
         Shares the policy with other user groups.
 
-        :sc-api:`scan-policy: share <Scan-Policy.html#ScanPolicyRESTReference-/policy/{id}/share>`
+        :sc-api:`scan-policy: share <Scan-Policy.htm#ScanPolicyRESTReference-/policy/{id}/share>`
 
         Args:
             id (int): The unique identifier for the scan policy to share.
@@ -478,7 +478,7 @@ class ScanPolicyAPI(SCEndpoint):
         '''
         Returns the list of unique tags associated to scan policies.
 
-        :sc-api:`scan-policy: tags <Scan-Policy.html#ScanPolicyRESTReference-/policy/tag>`
+        :sc-api:`scan-policy: tags <Scan-Policy.htm#ScanPolicyRESTReference-/policy/tag>`
 
         Returns:
             :obj:`list`:

--- a/tenable/sc/queries.py
+++ b/tenable/sc/queries.py
@@ -3,7 +3,7 @@ Queries
 =======
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`Query <Query.html>` API.  These items are typically seen
+:sc-api:`Query <Query.htm>` API.  These items are typically seen
 under the **Workflow -> Query** section of Tenable.sc.
 
 Methods available on ``sc.queries``:
@@ -82,7 +82,7 @@ class QueryAPI(SCEndpoint):
         '''
         Creates a query.
 
-        :sc-api:`query: create <Query.html#query_POST>`
+        :sc-api:`query: create <Query.htm#query_POST>`
 
         Args:
             name (str):
@@ -139,7 +139,7 @@ class QueryAPI(SCEndpoint):
         '''
         Returns the details for a specific query.
 
-        :sc-api:`query: details <Query.html#QueryRESTReference-/query/{id}>`
+        :sc-api:`query: details <Query.htm#QueryRESTReference-/query/{id}>`
 
         Args:
             id (int): The identifier for the query.
@@ -164,7 +164,7 @@ class QueryAPI(SCEndpoint):
         '''
         Edits a query.
 
-        :sc-api:`query: edit <Query.html#query_id_PATCH>`
+        :sc-api:`query: edit <Query.htm#query_id_PATCH>`
 
         Args:
             *filters (tuple, optional):
@@ -217,7 +217,7 @@ class QueryAPI(SCEndpoint):
         '''
         Removes a query.
 
-        :sc-api:`query: delete <Query.html#query_id_DELETE>`
+        :sc-api:`query: delete <Query.htm#query_id_DELETE>`
 
         Args:
             id (int): The numeric identifier for the query to remove.
@@ -236,7 +236,7 @@ class QueryAPI(SCEndpoint):
         '''
         Retrieves the list of query definitions.
 
-        :sc-api:`query: list <Query.html#QueryRESTReference-/query>`
+        :sc-api:`query: list <Query.htm#QueryRESTReference-/query>`
 
         Args:
             fields (list, optional):
@@ -261,7 +261,7 @@ class QueryAPI(SCEndpoint):
         '''
         Shares the specified query to another user group.
 
-        :sc-api:`query: share <Query.html#QueryRESTReference-/query/{id}/share>`
+        :sc-api:`query: share <Query.htm#QueryRESTReference-/query/{id}/share>`
 
         Args:
             id (int): The numeric id for the query.
@@ -283,7 +283,7 @@ class QueryAPI(SCEndpoint):
         '''
         Retrieves the list of unique tags associated to queries.
 
-        :sc-api:`query: tags <Query.html#QueryRESTReference-/query/tag>`
+        :sc-api:`query: tags <Query.htm#QueryRESTReference-/query/tag>`
 
         Returns:
             :obj:`list`:

--- a/tenable/sc/recast_risks.py
+++ b/tenable/sc/recast_risks.py
@@ -3,7 +3,7 @@ Recast Risks
 ============
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`Recast Risk <Recast-Risk-Rule.html>` API.
+:sc-api:`Recast Risk <Recast-Risk-Rule.htm>` API.
 
 Methods available on ``sc.recast_risks``:
 
@@ -83,7 +83,7 @@ class RecastRiskAPI(SCEndpoint):
         '''
         Retrieves the list of recasted risk rules.
 
-        :sc-api:`recast-risk: list <Recast-Risk-Rule.html#RecastRiskRuleRESTReference-/recastRiskRule>`
+        :sc-api:`recast-risk: list <Recast-Risk-Rule.htm#RecastRiskRuleRESTReference-/recastRiskRule>`
 
         Args:
             fields (list, optional):
@@ -140,7 +140,7 @@ class RecastRiskAPI(SCEndpoint):
         '''
         Retrieves the details of an recast risk rule.
 
-        :sc-api:`recast-risk: details <Recast-Risk-Rule.html#RecastRiskRuleRESTReference-/recastRiskRule/{id}>`
+        :sc-api:`recast-risk: details <Recast-Risk-Rule.htm#RecastRiskRuleRESTReference-/recastRiskRule/{id}>`
 
         Args:
             risk_id (int): The identifier for the recast risk rule.
@@ -167,7 +167,7 @@ class RecastRiskAPI(SCEndpoint):
         '''
         Removes the recast risk rule from Tenable.sc
 
-        :sc-api:`recast-risk: delete <hRecast-Risk-Rule.html#recastRiskRule_id_DELETE>`
+        :sc-api:`recast-risk: delete <Recast-Risk-Rule.htm#recastRiskRule_id_DELETE>`
 
         Args:
             risk_id (int): The identifier for the recast risk rule.
@@ -187,7 +187,7 @@ class RecastRiskAPI(SCEndpoint):
         Applies the recast risk rule for either all repositories, or the
         repository specified.
 
-        :sc-api:`recast-risk: apply <Recast-Risk-Rule.html#RecastRiskRuleRESTReference-/recastRiskRule/apply>`
+        :sc-api:`recast-risk: apply <Recast-Risk-Rule.htm#RecastRiskRuleRESTReference-/recastRiskRule/apply>`
 
         Args:
             risk_id (int): The identifier for the recast risk rule.
@@ -212,7 +212,7 @@ class RecastRiskAPI(SCEndpoint):
         Creates a new recast risk rule.  Either ips, uuids, or asset_list must
         be specified.
 
-        :sc-api:`recast-risk: create <Recast-Risk-Rule.html#recastRiskRule_POST>`
+        :sc-api:`recast-risk: create <Recast-Risk-Rule.htm#recastRiskRule_POST>`
 
         Args:
             plugin_id (int): The plugin to apply the recast risk rule to.

--- a/tenable/sc/repositories.py
+++ b/tenable/sc/repositories.py
@@ -3,7 +3,7 @@ Repositories
 ============
 
 The following methods allow for interaction with the Tenable.sc
-:sc-api:`Repository <Repository.html>` API.  These items are typically seen
+:sc-api:`Repository <Repository.htm>` API.  These items are typically seen
 under the **Repositories** section of Tenable.sc.
 
 Methods available on ``sc.repositories``:
@@ -178,7 +178,7 @@ class RepositoryAPI(SCEndpoint):
         '''
         Creates a new repository
 
-        :sc-api:`repository: create <Repository.html#repository_POST>`
+        :sc-api:`repository: create <Repository.htm#repository_POST>`
 
         Args:
             name (str): The name for the respository.
@@ -335,7 +335,7 @@ class RepositoryAPI(SCEndpoint):
         '''
         Retrieves the details for the specified repository.
 
-        :sc-api:`repository: details <Repository.html#repository_id_GET>`
+        :sc-api:`repository: details <Repository.htm#repository_id_GET>`
 
         Args:
             repository_id (int): The numeric id of the repository.
@@ -362,7 +362,7 @@ class RepositoryAPI(SCEndpoint):
         '''
         Remove the specified repository from Tenable.sc
 
-        :sc-api:`repository: delete <Repository.html#repository_id_DELETE>`
+        :sc-api:`repository: delete <Repository.htm#repository_id_DELETE>`
 
         Args:
             repository_id (int): The numeric id of the repository to delete.
@@ -381,7 +381,7 @@ class RepositoryAPI(SCEndpoint):
         '''
         Updates an existing repository
 
-        :sc-api:`repository: edit <Repository.html#repository_id_PATCH>`
+        :sc-api:`repository: edit <Repository.htm#repository_id_PATCH>`
 
         Args:
             repository_id (int): The numeric id of the repository to edit.
@@ -447,7 +447,7 @@ class RepositoryAPI(SCEndpoint):
         Retrieves the accepted risk rules associated with the specified
         repository.
 
-        :sc-api:`repository: accept rules <Repository.html#RepositoryRESTReference-/repository/{id}/acceptRiskRule>`
+        :sc-api:`repository: accept rules <Repository.htm#RepositoryRESTReference-/repository/{id}/acceptRiskRule>`
 
         Args:
             repository_id (int): The numeric id of the repository.
@@ -473,7 +473,7 @@ class RepositoryAPI(SCEndpoint):
         repository.
 
         :sc-api:`repository: recast rules
-        <Repository.html#RepositoryRESTReference-/repository/{repository_id}/recastRiskRule>`
+        <Repository.htm#RepositoryRESTReference-/repository/{repository_id}/recastRiskRule>`
 
         Args:
             repository_id (int): The numeric id of the repository.
@@ -498,7 +498,7 @@ class RepositoryAPI(SCEndpoint):
         Retrieves the asset lists that a UUID, DNS address, or IP exists in.
 
         :sc-api:`repository: asst intersections
-        <Repository.html#RepositoryRESTReference-/repository/{repository_id}/assetIntersections>`
+        <Repository.htm#RepositoryRESTReference-/repository/{repository_id}/assetIntersections>`
 
         Args:
             repository_id (int): The numeric identifier of the repository to query.
@@ -529,7 +529,7 @@ class RepositoryAPI(SCEndpoint):
         '''
         Imports the repository archive for an offline repository.
 
-        :sc-api:`repository: import <Repository.html#RepositoryRESTReference-/repository/{repository_id}/import>`
+        :sc-api:`repository: import <Repository.htm#RepositoryRESTReference-/repository/{repository_id}/import>`
 
         Args:
             repository_id (int): The numeric id associated to the offline repository.
@@ -554,7 +554,7 @@ class RepositoryAPI(SCEndpoint):
         Exports the repository and writes the archive tarball into the file
         object passed.
 
-        :sc-api:`repository: export <Repository.html#RepositoryRESTReference-/repository/{repository_id}/export>`
+        :sc-api:`repository: export <Repository.htm#RepositoryRESTReference-/repository/{repository_id}/export>`
 
         Args:
             repository_id (int): The numeric id associated to the repository.
@@ -585,7 +585,7 @@ class RepositoryAPI(SCEndpoint):
         Initiates a remote synchronization with a downstream Tenable.sc
         instance.  This action can only be performed on an offline repository.
 
-        :sc-api:`repository: sync <Repository.html#RepositoryRESTReference-/repository/{repository_id}/sync>`
+        :sc-api:`repository: sync <Repository.htm#RepositoryRESTReference-/repository/{repository_id}/sync>`
 
         Args:
             repository_id (int): The numeric id for the remote repository.
@@ -606,7 +606,7 @@ class RepositoryAPI(SCEndpoint):
         mobile repository specified.
 
         :sc-api:`repository: update mobile data
-        <Repository.html#RepositoryRESTReference-/repository/{repository_id}/updateMobileData>`
+        <Repository.htm#RepositoryRESTReference-/repository/{repository_id}/updateMobileData>`
 
         Args:
             repository_id (int): The numeric id for the mobile repository to run the sync.
@@ -627,9 +627,9 @@ class RepositoryAPI(SCEndpoint):
         associated repository.
 
         :sc-api:`repository: device info
-        <Repository.html#RepositoryRESTReference-/repository/{repository_id}/deviceInfo>`
+        <Repository.htm#RepositoryRESTReference-/repository/{repository_id}/deviceInfo>`
 
-        `repository: ip info <Repository.html#RepositoryRESTReference-/repository/{id}/ipInfo>`
+        `repository: ip info <Repository.htm#RepositoryRESTReference-/repository/{id}/ipInfo>`
 
         Args:
             repository_id (int): The numeric id for the repository to query.
@@ -677,7 +677,7 @@ class RepositoryAPI(SCEndpoint):
         Authorized communication to a downstream Tenable.sc instance with the
         provided username and password.
 
-        :sc-api:`repository: authorize <Repository.html#RepositoryRESTReference-/repository/authorize>`
+        :sc-api:`repository: authorize <Repository.htm#RepositoryRESTReference-/repository/authorize>`
 
         Args:
             host (str): The downstream Tenable.sc instance ip address.
@@ -703,7 +703,7 @@ class RepositoryAPI(SCEndpoint):
         Retrieves the list of repositories from the specified downstream
         Tenable.sc instance.
 
-        :sc-api:`repository: fetch remote <Repository.html#RepositoryRESTReference-/repository/fetchRemote>`
+        :sc-api:`repository: fetch remote <Repository.htm#RepositoryRESTReference-/repository/fetchRemote>`
 
         Args:
             host (str): The downstream Tenable.sc instance ip address.

--- a/tenable/sc/roles.py
+++ b/tenable/sc/roles.py
@@ -3,7 +3,7 @@ Roles
 =====
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`Roles <Role.html>` API.  These items are typically seen under the
+:sc-api:`Roles <Role.htm>` API.  These items are typically seen under the
 **User Roles** section of Tenable.sc.
 
 Methods available on ``sc.roles``:
@@ -72,7 +72,7 @@ class RoleAPI(SCEndpoint):
         '''
         Creates a role.
 
-        :sc-api:`role: create <Role.html#role_POST>`
+        :sc-api:`role: create <Role.htm#role_POST>`
 
         Args:
             name (str): The name of the new role to create.
@@ -154,7 +154,7 @@ class RoleAPI(SCEndpoint):
         '''
         Returns the details for a specific role.
 
-        :sc-api:`role: details <Role.html#role_id_GET>`
+        :sc-api:`role: details <Role.htm#role_id_GET>`
 
         Args:
             id (int): The identifier for the role.
@@ -179,7 +179,7 @@ class RoleAPI(SCEndpoint):
         '''
         Edits a role.
 
-        :sc-api:`role: edit <Role.html#role_id_PATCH>`
+        :sc-api:`role: edit <Role.htm#role_id_PATCH>`
 
         Args:
             id (int): The numeric identifier for the role.
@@ -261,7 +261,7 @@ class RoleAPI(SCEndpoint):
         '''
         Removes a role.
 
-        :sc-api:`role: delete <Role.html#role_id_DELETE>`
+        :sc-api:`role: delete <Role.htm#role_id_DELETE>`
 
         Args:
             id (int): The numeric identifier for the role to remove.
@@ -281,7 +281,7 @@ class RoleAPI(SCEndpoint):
         '''
         Retrieves the list of role definitions.
 
-        :sc-api:`role: list <Role.html#role_GET>`
+        :sc-api:`role: list <Role.htm#role_GET>`
 
         Args:
             fields (list, optional):

--- a/tenable/sc/scan_instances.py
+++ b/tenable/sc/scan_instances.py
@@ -3,7 +3,7 @@ Scan Instances
 ==============
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`Scan Result <Scan-Result.html>` API.  While the Tenable.sc API refers
+:sc-api:`Scan Result <Scan-Result.htm>` API.  While the Tenable.sc API refers
 to the model these endpoints interact with as *ScanResult*, were actually
 interacting with an instance of a scan definition stored within the *Scan* API
 endpoints.  These scan instances could be running scans, stopped scans, errored
@@ -25,7 +25,7 @@ class ScanResultAPI(SCEndpoint):
         '''
         Clones the scan instance.
 
-        :sc-api:`scan-result: copy <Scan-Result.html#ScanResultRESTReference-/scanResult/{id}/copy>`
+        :sc-api:`scan-result: copy <Scan-Result.htm#ScanResultRESTReference-/scanResult/{id}/copy>`
 
         Args:
             id (int): The identifier of the scan instance to clone.
@@ -49,7 +49,7 @@ class ScanResultAPI(SCEndpoint):
         '''
         Removes the scan instance from TenableSC.
 
-        :sc-api:`scan-result: delete <Scan-Result.html#scanResult_id_DELETE>`
+        :sc-api:`scan-result: delete <Scan-Result.htm#scanResult_id_DELETE>`
 
         Args:
             id (int): The identifier of the scan instance to delete.
@@ -68,7 +68,7 @@ class ScanResultAPI(SCEndpoint):
         '''
         Retrieves the details for the specified scan instance.
 
-        :sc-api:`scan-result: details <Scan-Result.html#scanResult_id_GET>`
+        :sc-api:`scan-result: details <Scan-Result.htm#scanResult_id_GET>`
 
         Args:
             id (int): The identifier for the scan instance to be retrieved.
@@ -105,7 +105,7 @@ class ScanResultAPI(SCEndpoint):
         Emails the scan results of the requested scan to the email addresses
         defined.
 
-        :sc-api:`scan-result: email <Scan-Result.html#ScanResultRESTReference-/scanResult/{id}/email>`
+        :sc-api:`scan-result: email <Scan-Result.htm#ScanResultRESTReference-/scanResult/{id}/email>`
 
         Args:
             id (int): The identifier for the specified scan instance.
@@ -126,7 +126,7 @@ class ScanResultAPI(SCEndpoint):
         '''
         Downloads the results of the scan.
 
-        :sc-api:`scan-result: download <Scan-Result.html#ScanResultRESTReference-/scanResult/{id}/download>`
+        :sc-api:`scan-result: download <Scan-Result.htm#ScanResultRESTReference-/scanResult/{id}/download>`
 
         Args:
             id (int): The scan instance identifier.
@@ -172,7 +172,7 @@ class ScanResultAPI(SCEndpoint):
         '''
         Imports a nessus file into Tenable.sc.
 
-        :sc-api:`scan-result: import <Scan-Result.html#ScanResultRESTReference-/scanResult/import>`
+        :sc-api:`scan-result: import <Scan-Result.htm#ScanResultRESTReference-/scanResult/import>`
 
         Args:
             fobj (FileObject):
@@ -206,7 +206,7 @@ class ScanResultAPI(SCEndpoint):
         '''
         Re-imports an existing scan into the cumulative repository.
 
-        :sc-api:`scan-result: re-import <Scan-Result.html#ScanResultRESTReference-/scanResult/{id}/import>`
+        :sc-api:`scan-result: re-import <Scan-Result.htm#ScanResultRESTReference-/scanResult/{id}/import>`
 
         Args:
             id (int):
@@ -235,7 +235,7 @@ class ScanResultAPI(SCEndpoint):
         '''
         Retrieves the list of scan instances.
 
-        :sc-api:`scan-result: list <Scan-Result.html#ScanResultRESTReference-/scanResult>`
+        :sc-api:`scan-result: list <Scan-Result.htm#ScanResultRESTReference-/scanResult>`
 
         Args:
             fields (list, optional):
@@ -278,7 +278,7 @@ class ScanResultAPI(SCEndpoint):
         Pauses a running scan instance.  Note that this will not impact agent
         scan instances.
 
-        "sc-api:`scan-result: pause <Scan-Result.html#ScanResultRESTReference-/scanResult/{id}/pause>`
+        "sc-api:`scan-result: pause <Scan-Result.htm#ScanResultRESTReference-/scanResult/{id}/pause>`
 
         Args:
             id (int): The unique identifier for the scan instance.
@@ -298,7 +298,7 @@ class ScanResultAPI(SCEndpoint):
         Resumes a paused scan instance.  Note that this will not impact agent
         scan instances.
 
-        :sc-api:`scan-result: resume <Scan-Result.html#ScanResultRESTReference-/scanResult/{id}/resume>`
+        :sc-api:`scan-result: resume <Scan-Result.htm#ScanResultRESTReference-/scanResult/{id}/resume>`
 
         Args:
             id (int): The unique identifier for the scan instance.
@@ -318,7 +318,7 @@ class ScanResultAPI(SCEndpoint):
         Stops a running scan instance.  Note that this will not impact agent
         scan instances.
 
-        :sc-api:`scan-result: stop <Scan-Result.html#ScanResultRESTReference-/scanResult/{id}/stop>`
+        :sc-api:`scan-result: stop <Scan-Result.htm#ScanResultRESTReference-/scanResult/{id}/stop>`
 
         Args:
             id (int): The unique identifier for the scan instance.

--- a/tenable/sc/scan_zones.py
+++ b/tenable/sc/scan_zones.py
@@ -3,7 +3,7 @@ Scan Zones
 ==========
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`Scan Zone <Scan-Zone.html>` API.  These items are typically seen under
+:sc-api:`Scan Zone <Scan-Zone.htm>` API.  These items are typically seen under
 the **Scan Zones** section of Tenable.sc.
 
 Methods available on ``sc.scan_zones``:
@@ -47,7 +47,7 @@ class ScanZoneAPI(SCEndpoint):
         '''
         Creates a scan zone.
 
-        :sc-api:`scan-zone: create <Scan-Zone.html#zone_POST>`
+        :sc-api:`scan-zone: create <Scan-Zone.htm#zone_POST>`
 
         Args:
             name (str): The name of the scan zone
@@ -75,7 +75,7 @@ class ScanZoneAPI(SCEndpoint):
         '''
         Returns the details for a specific scan zone.
 
-        :sc-api:`scan-zone: details <Scan-Zone.html#zone_id_GET>`
+        :sc-api:`scan-zone: details <Scan-Zone.htm#zone_id_GET>`
 
         Args:
             id (int): The identifier for the scan.
@@ -100,7 +100,7 @@ class ScanZoneAPI(SCEndpoint):
         '''
         Edits a scan zone.
 
-        :sc-api:`scan-zone: edit <Scan-Zone.html#zone_id_PATCH>`
+        :sc-api:`scan-zone: edit <Scan-Zone.htm#zone_id_PATCH>`
 
         Args:
             description (str, optional):
@@ -129,7 +129,7 @@ class ScanZoneAPI(SCEndpoint):
         '''
         Retrieves the list of scan zone definitions.
 
-        :sc-api:`scan-zone: list <Scan-Zone.html#zone_GET>`
+        :sc-api:`scan-zone: list <Scan-Zone.htm#zone_GET>`
 
         Args:
             fields (list, optional):
@@ -154,7 +154,7 @@ class ScanZoneAPI(SCEndpoint):
         '''
         Removes the specified scan zone.
 
-        :sc-api:`scan-zone: delete <Scan-Zone.html#zone_id_DELETE>`
+        :sc-api:`scan-zone: delete <Scan-Zone.htm#zone_id_DELETE>`
 
         Args:
             id (int): The numeric identifier for the scan-zone to remove.

--- a/tenable/sc/scanners.py
+++ b/tenable/sc/scanners.py
@@ -3,7 +3,7 @@ Scanners
 ========
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`Scanner <Scanner.html>` API.  These items are typically seen under the
+:sc-api:`Scanner <Scanner.htm>` API.  These items are typically seen under the
 **Scanners** section of Tenable.sc.
 
 Methods available on ``sc.scanners``:
@@ -114,7 +114,7 @@ class ScannerAPI(SCEndpoint):
         '''
         Creates a scanner.
 
-        :sc-api:`scanner: create <Scanner.html#scanner_POST>`
+        :sc-api:`scanner: create <Scanner.htm#scanner_POST>`
 
         Args:
             address (str): The address of the scanner
@@ -167,7 +167,7 @@ class ScannerAPI(SCEndpoint):
         '''
         Returns the details for a specific scanner.
 
-        :sc-api:`scanner: details <Scanner.html#scanner_POST>`
+        :sc-api:`scanner: details <Scanner.htm#scanner_POST>`
 
         Args:
             id (int): The identifier for the scanner.
@@ -192,7 +192,7 @@ class ScannerAPI(SCEndpoint):
         '''
         Edits a scanner.
 
-        :sc-api:`scanner: edit <Scanner.html#scanner_id_PATCH>`
+        :sc-api:`scanner: edit <Scanner.htm#scanner_id_PATCH>`
 
         Args:
             id (int): The numeric identifier for the scanner.
@@ -237,7 +237,7 @@ class ScannerAPI(SCEndpoint):
         '''
         Removes the specified scanner.
 
-        :sc-api:`scanner: delete <Scanner.html#scanner_id_DELETE>`
+        :sc-api:`scanner: delete <Scanner.htm#scanner_id_DELETE>`
 
         Args:
             id (int): The numeric identifier for the scanner to remove.
@@ -256,7 +256,7 @@ class ScannerAPI(SCEndpoint):
         '''
         Retrieves the list of scanner definitions.
 
-        :sc-api:`scanner: list <Scanner.html#scanner_GET>`
+        :sc-api:`scanner: list <Scanner.htm#scanner_GET>`
 
         Args:
             fields (list, optional):
@@ -282,7 +282,7 @@ class ScannerAPI(SCEndpoint):
         Retrieves the list of agent scans that meed the specified search
         criteria.
 
-        :sc-api:`scanner: test-scans-query <Scanner.html#ScannerRESTReference-/scanner/{id}/testScansQuery>`
+        :sc-api:`scanner: test-scans-query <Scanner.htm#ScannerRESTReference-/scanner/{id}/testScansQuery>`
 
         Args:
             id (int): The numeric id of the scanner.
@@ -309,7 +309,7 @@ class ScannerAPI(SCEndpoint):
         '''
         Starts an on-demand scanner status update.
 
-        :sc-api:`scanner: update-status <Scanner.html#ScannerRESTReference-/scanner/updateStatus>`
+        :sc-api:`scanner: update-status <Scanner.htm#ScannerRESTReference-/scanner/updateStatus>`
 
         Returns:
             :obj:`list`:

--- a/tenable/sc/scans.py
+++ b/tenable/sc/scans.py
@@ -3,7 +3,7 @@ Scans
 =====
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`Scan <Scan.html>` API.  While the api endpoints obliquely refers to the
+:sc-api:`Scan <Scan.htm>` API.  While the api endpoints obliquely refers to the
 model in which this collection of actions modifies as "Scans", Tenable.sc is
 actually referring to the scan *definitions*, which are the un-launched and/or
 scheduled scans typically seen within the **Active Scans** section within
@@ -178,7 +178,7 @@ class ScanAPI(SCEndpoint):
         '''
         Retrieves the list of scan definitions.
 
-        :sc-api:scan: list <Scan.html#scan_GET>`
+        :sc-api:scan: list <Scan.htm#scan_GET>`
 
         Args:
             fields (list, optional):
@@ -203,7 +203,7 @@ class ScanAPI(SCEndpoint):
         '''
         Creates a scan definition.
 
-        :sc-api:`scan: create <Scan.html#scan_POST>`
+        :sc-api:`scan: create <Scan.htm#scan_POST>`
 
         Args:
             name (str): The name of the scan.
@@ -287,7 +287,7 @@ class ScanAPI(SCEndpoint):
         '''
         Returns the details for a specific scan.
 
-        :sc-api:`scan: details <Scan.html#ScanRESTReference-/scan/{id}>`
+        :sc-api:`scan: details <Scan.htm#ScanRESTReference-/scan/{id}>`
 
         Args:
             id (int): The identifier for the scan.
@@ -312,7 +312,7 @@ class ScanAPI(SCEndpoint):
         '''
         Edits an existing scan definition.
 
-        :sc-api:`scan: update <Scan.html#scan_id_PATCH>`
+        :sc-api:`scan: update <Scan.htm#scan_id_PATCH>`
 
         Args:
             id (int): The identifier for the scan.
@@ -382,7 +382,7 @@ class ScanAPI(SCEndpoint):
         '''
         Removes the specified scan from SecurityCenter.
 
-        :sc-api:`scan: delete <Scan.html#scan_id_DELETE>`
+        :sc-api:`scan: delete <Scan.htm#scan_id_DELETE>`
 
         Args:
             id (int): The identifier for the scan to delete.
@@ -401,7 +401,7 @@ class ScanAPI(SCEndpoint):
         '''
         Copies an existing scan definition.
 
-        :sc-api:`scan: copy <Scan.html#ScanRESTReference-/scan/{id}/copyScanCopyPOST>`
+        :sc-api:`scan: copy <Scan.htm#ScanRESTReference-/scan/{id}/copyScanCopyPOST>`
 
         Args:
             id (int): The scan definition identifier to copy.
@@ -428,7 +428,7 @@ class ScanAPI(SCEndpoint):
         '''
         Launches a scan definition.
 
-        :sc-api:`scan: launch <Scan.html#ScanRESTReference-/scan/{id}/launch>`
+        :sc-api:`scan: launch <Scan.htm#ScanRESTReference-/scan/{id}/launch>`
 
         Args:
             id (int): The scan definition identifier to launch.

--- a/tenable/sc/status.py
+++ b/tenable/sc/status.py
@@ -3,7 +3,7 @@ Status
 ======
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`Status <Status.html>` API.  These API calls are typically used to
+:sc-api:`Status <Status.htm>` API.  These API calls are typically used to
 understand the current job and license statuses.
 
 Methods available on ``sc.status``:
@@ -19,7 +19,7 @@ class StatusAPI(SCEndpoint):
         '''
         Retrieves license & status information about the Tenable.sc instance.
 
-        :sc-api:`status: status <Status.html#StatusRESTReference-/status>`
+        :sc-api:`status: status <Status.htm#StatusRESTReference-/status>`
 
         Returns:
             :obj:`dict`:

--- a/tenable/sc/system.py
+++ b/tenable/sc/system.py
@@ -3,7 +3,7 @@ System
 ======
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`System <System.html>` API.  These API calls are typically used to
+:sc-api:`System <System.htm>` API.  These API calls are typically used to
 understand timezones, system version, etc.
 
 Methods available on ``sc.system``:
@@ -24,7 +24,7 @@ class SystemAPI(SCEndpoint):
         information within this call already happens upon instantiation, there
         should be little need to call this manually.
 
-        :sc-api:'system: get <System.html#system_GET>`
+        :sc-api:'system: get <System.htm#system_GET>`
 
         Returns:
             :obj:`dict`:
@@ -40,9 +40,9 @@ class SystemAPI(SCEndpoint):
         Generates and downloads a diagnostic file for the purpose of
         troubleshooting an ailing Tenable.sc instance.
 
-        :sc-api:`system: diagnostics-generate <System.html#SystemRESTReference-/system/diagnostics/generate>`
+        :sc-api:`system: diagnostics-generate <System.htm#SystemRESTReference-/system/diagnostics/generate>`
 
-        :sc-api:`system: diagnostics-download <System.html#SystemRESTReference-/system/diagnostics/download>`
+        :sc-api:`system: diagnostics-download <System.htm#SystemRESTReference-/system/diagnostics/download>`
 
         Args:
             fobj (FileObject, optional):
@@ -117,7 +117,7 @@ class SystemAPI(SCEndpoint):
         '''
         Retrieves the current system locale that Tenable.sc has been set to.
 
-        :sc-api:`system: locale <System.html#SystemRESTReference-/system/locale>`
+        :sc-api:`system: locale <System.htm#SystemRESTReference-/system/locale>`
 
         Returns:
             :obj:`dict`:
@@ -132,7 +132,7 @@ class SystemAPI(SCEndpoint):
         '''
         Retrieves the available system locales that Tenable.sc can be set to.
 
-        :sc-api:`system: locales <System.html#SystemRESTReference-/system/locales>`
+        :sc-api:`system: locales <System.htm#SystemRESTReference-/system/locales>`
 
         Returns:
             :obj:`dict`:
@@ -149,7 +149,7 @@ class SystemAPI(SCEndpoint):
         perform this task and will be a global change.  The locale determines
         which pluginset language to use.
 
-        :sc-api:`system: set-locale <System.html#system_locale_PATCH>`
+        :sc-api:`system: set-locale <System.htm#system_locale_PATCH>`
 
         Args:
             locale (str): The plugin locale name
@@ -171,7 +171,7 @@ class SystemAPI(SCEndpoint):
         '''
         Retrieves the current system status
 
-        :sc-api:`system: diagnostics <System.html#SystemRESTReference-/system/diagnostics>`
+        :sc-api:`system: diagnostics <System.htm#SystemRESTReference-/system/diagnostics>`
 
         Returns:
             :obj:`dict`:

--- a/tenable/sc/users.py
+++ b/tenable/sc/users.py
@@ -3,7 +3,7 @@ Users
 =====
 
 The following methods allow for interaction into the Tenable.sc
-:sc-api:`User <User.html>` API.  These items are typically seen under the
+:sc-api:`User <User.htm>` API.  These items are typically seen under the
 **Users** section of Tenable.sc.
 
 Methods available on ``sc.users``:
@@ -139,7 +139,7 @@ class UserAPI(SCEndpoint):
         '''
         Creates a user.
 
-        :sc-api:`user: create <User.html#user_POST>`
+        :sc-api:`user: create <User.htm#user_POST>`
 
         Args:
             username (str):
@@ -235,7 +235,7 @@ class UserAPI(SCEndpoint):
         '''
         Returns the details for a specific user.
 
-        :sc-api:`user: details <User.html#UserRESTReference-/user/{id}>`
+        :sc-api:`user: details <User.htm#UserRESTReference-/user/{id}>`
 
         Args:
             id (int): The identifier for the user.
@@ -260,7 +260,7 @@ class UserAPI(SCEndpoint):
         '''
         Edits a user.
 
-        :sc-api:`user: edit <User.html#user_id_PATCH>`
+        :sc-api:`user: edit <User.htm#user_id_PATCH>`
 
         Args:
             address (str, optional):
@@ -352,7 +352,7 @@ class UserAPI(SCEndpoint):
         '''
         Removes a user.
 
-        :sc-api:`user: delete <User.html#user_id_DELETE>`
+        :sc-api:`user: delete <User.htm#user_id_DELETE>`
 
         Args:
             id (int): The numeric identifier for the user to remove.
@@ -371,7 +371,7 @@ class UserAPI(SCEndpoint):
         '''
         Retrieves the list of user definitions.
 
-        :sc-api:`user: list <User.html#user_GET>`
+        :sc-api:`user: list <User.htm#user_GET>`
 
         Args:
             fields (list, optional):


### PR DESCRIPTION
# Description

Updated the Security Center API documentation links and the Tenable Developer Portal links.

These updates were needed due changes to the URL structure for the Security Center documentation on docs.tenable.com for product rebranding and other updates. Additionally, the links to the Developer Portal were using outdated paths.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I verified the links would work based on my access to the docs.tenable.com and developer.tenable.com source directory structures. I also manually tested the links.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules